### PR TITLE
Update runtime to 48

### DIFF
--- a/de.k_bo.Televido.json
+++ b/de.k_bo.Televido.json
@@ -1,11 +1,11 @@
 {
   "id": "de.k_bo.Televido",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.rust-stable",
-    "org.freedesktop.Sdk.Extension.llvm19"
+    "org.freedesktop.Sdk.Extension.llvm20"
   ],
   "command": "televido",
   "finish-args": [
@@ -22,7 +22,7 @@
     "--talk-name=org.nickvision.tubeconverter"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm19/bin",
+    "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm20/bin",
     "env": {
       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "clang",
       "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER": "clang",
@@ -70,8 +70,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-          "tag": "v0.12.0"
+          "url": "https://github.com/GNOME/blueprint-compiler",
+          "tag": "v0.18.0"
         }
       ]
     },


### PR DESCRIPTION
This updates the GNOME runtime to 48, and bumps llvm to 20 and blueprint-compiler to 0.18.0, as the GNOME 47 runtime is about to be deprecated.

(I originally wanted to update to the new GNOME 49 runtime, but that (unlike 48) had visible regressions - the logos of the TV channels would not load with 49.)

